### PR TITLE
Change the way dagpenger calculate 'sisteAvsluttendeKalendermåned' ka…

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/events/inntekt/v1/Inntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/events/inntekt/v1/Inntekt.kt
@@ -1,31 +1,34 @@
 package no.nav.dagpenger.events.inntekt.v1
 
-import java.lang.IllegalArgumentException
 import java.time.YearMonth
 
 class Inntekt(
     val inntektsId: String,
     val inntektsListe: List<KlassifisertInntektMåned>,
-    val manueltRedigert: Boolean? = false
+    val manueltRedigert: Boolean? = false,
+    val sisteAvsluttendeKalenderMåned: YearMonth
 ) {
 
-    fun splitIntoInntektsPerioder(senesteMåned: YearMonth): InntektsPerioder {
+    fun splitIntoInntektsPerioder(): InntektsPerioder {
         return Triple(
             (0L..11L).map { i ->
-                inntektsListe.find { it.årMåned == senesteMåned.minusMonths(i) } ?: KlassifisertInntektMåned(
-                    senesteMåned.minusMonths(i),
+                inntektsListe.find { it.årMåned == sisteAvsluttendeKalenderMåned.minusMonths(i) }
+                    ?: KlassifisertInntektMåned(
+                        sisteAvsluttendeKalenderMåned.minusMonths(i),
                     emptyList()
                 )
             }.sortedBy { it.årMåned },
             (12L..23L).map { i ->
-                inntektsListe.find { it.årMåned == senesteMåned.minusMonths(i) } ?: KlassifisertInntektMåned(
-                    senesteMåned.minusMonths(i),
+                inntektsListe.find { it.årMåned == sisteAvsluttendeKalenderMåned.minusMonths(i) }
+                    ?: KlassifisertInntektMåned(
+                        sisteAvsluttendeKalenderMåned.minusMonths(i),
                     emptyList()
                 )
             }.sortedBy { it.årMåned },
             (24L..35L).map { i ->
-                inntektsListe.find { it.årMåned == senesteMåned.minusMonths(i) } ?: KlassifisertInntektMåned(
-                    senesteMåned.minusMonths(i),
+                inntektsListe.find { it.årMåned == sisteAvsluttendeKalenderMåned.minusMonths(i) }
+                    ?: KlassifisertInntektMåned(
+                        sisteAvsluttendeKalenderMåned.minusMonths(i),
                     emptyList()
                 )
             }.sortedBy { it.årMåned }
@@ -34,6 +37,10 @@ class Inntekt(
 
     fun filterPeriod(from: YearMonth, to: YearMonth): Inntekt {
         if (from.isAfter(to)) throw IllegalArgumentException("Argument from=$from is after argument to=$to")
-        return Inntekt(inntektsId, inntektsListe.filter { it.årMåned !in from..to })
+        return Inntekt(
+            inntektsId,
+            inntektsListe.filter { it.årMåned !in from..to },
+            sisteAvsluttendeKalenderMåned = sisteAvsluttendeKalenderMåned
+        )
     }
 }

--- a/src/test/kotlin/no/nav/dagpenger/events/inntekt/v1/KlassifisertInntektMånedTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/events/inntekt/v1/KlassifisertInntektMånedTest.kt
@@ -25,7 +25,7 @@ class KlassifisertInntektMånedTest {
         )
     }
 
-    val testInntekt = Inntekt("id", testInntektsListe)
+    val testInntekt = Inntekt("id", testInntektsListe, sisteAvsluttendeKalenderMåned = senesteMåned)
 
     @Test
     fun `sum with empty list of inntektsklasserToSum returns 0`() {
@@ -41,12 +41,12 @@ class KlassifisertInntektMånedTest {
     fun ` should sum arbeidsinntekt correctly`() {
         assertEquals(
             BigDecimal(12000),
-            testInntekt.splitIntoInntektsPerioder(senesteMåned).first.sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))
+            testInntekt.splitIntoInntektsPerioder().first.sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))
         )
 
         assertEquals(
             BigDecimal(36000),
-            testInntekt.splitIntoInntektsPerioder(senesteMåned).all().sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))
+            testInntekt.splitIntoInntektsPerioder().all().sumInntekt(listOf(InntektKlasse.ARBEIDSINNTEKT))
         )
     }
 
@@ -54,12 +54,12 @@ class KlassifisertInntektMånedTest {
     fun ` should sum dp fangst fiske correctly `() {
         assertEquals(
             BigDecimal(24000),
-            testInntekt.splitIntoInntektsPerioder(senesteMåned).first.sumInntekt(listOf(InntektKlasse.DAGPENGER_FANGST_FISKE))
+            testInntekt.splitIntoInntektsPerioder().first.sumInntekt(listOf(InntektKlasse.DAGPENGER_FANGST_FISKE))
         )
 
         assertEquals(
             BigDecimal(72000),
-            testInntekt.splitIntoInntektsPerioder(senesteMåned).all().sumInntekt(listOf(InntektKlasse.DAGPENGER_FANGST_FISKE))
+            testInntekt.splitIntoInntektsPerioder().all().sumInntekt(listOf(InntektKlasse.DAGPENGER_FANGST_FISKE))
         )
     }
 
@@ -67,7 +67,7 @@ class KlassifisertInntektMånedTest {
     fun ` should sum multiple inntektsklasser`() {
         assertEquals(
             BigDecimal(36000),
-            testInntekt.splitIntoInntektsPerioder(senesteMåned).first.sumInntekt(
+            testInntekt.splitIntoInntektsPerioder().first.sumInntekt(
                 listOf(
                     InntektKlasse.DAGPENGER_FANGST_FISKE,
                     InntektKlasse.ARBEIDSINNTEKT
@@ -77,7 +77,7 @@ class KlassifisertInntektMånedTest {
 
         assertEquals(
             BigDecimal(108000),
-            testInntekt.splitIntoInntektsPerioder(senesteMåned).all().sumInntekt(
+            testInntekt.splitIntoInntektsPerioder().all().sumInntekt(
                 listOf(
                     InntektKlasse.DAGPENGER_FANGST_FISKE,
                     InntektKlasse.ARBEIDSINNTEKT


### PR DESCRIPTION
…lendermåned. Only fetch salary for the restricted to dates (to -from dates) given by 'Opptjeningsperiode'

Find period based on 'sisteAvsluttendeKalendermåned' and not a date given from 'outside' as this violates single responsibility principle