### PR TITLE
Add correlation id to packet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,10 @@ val sourcesJar by tasks.registering(Jar::class) {
     from(sourceSets["main"].allSource)
 }
 
+tasks.named("compileKotlin") {
+    dependsOn("spotlessCheck")
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
     testLogging {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk12

--- a/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
+++ b/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
@@ -129,12 +129,11 @@ class Packet constructor(jsonString: String = "{}") {
         getNullableObjectValue(key, decode) ?: throw IllegalArgumentException("Null value for key=$key")
 
     fun getBoolean(key: String) = getNullableBoolean(key) ?: throw IllegalArgumentException("Null value for key=$key")
-
+    
     fun getMapValue(key: String): Map<String, Any> {
         return getValue(key).takeIf { it is Map<*, *> }.let {
             try {
-                it as Ma
-                p<String, Any>
+                it as Map<String, Any>
             } catch (e: TypeCastException) {
                 throw IllegalArgumentException("Not a map value for key=$key")
             }

--- a/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
+++ b/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
@@ -19,7 +19,7 @@ class Packet constructor(jsonString: String = "{}") {
         internal const val BREADCRUMBS = "system_breadcrumbs"
 
         private val adapter = moshiInstance.adapter<Map<String, Any?>>(Map::class.java).lenient()
-        private val ulidGen =  ULID()
+        private val ulidGen = ULID()
     }
 
     private var problem: Problem? = null
@@ -133,7 +133,8 @@ class Packet constructor(jsonString: String = "{}") {
     fun getMapValue(key: String): Map<String, Any> {
         return getValue(key).takeIf { it is Map<*, *> }.let {
             try {
-                it as Map<String, Any>
+                it as Ma
+                p<String, Any>
             } catch (e: TypeCastException) {
                 throw IllegalArgumentException("Not a map value for key=$key")
             }
@@ -153,5 +154,4 @@ class Packet constructor(jsonString: String = "{}") {
     fun getBreadcrumbs(): List<Breadcrumb> = breadcrumbs
 
     fun getReadCount(): Int = getIntValue(READ_COUNT)
-
 }

--- a/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
+++ b/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.events
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.Types
+import de.huxhorn.sulky.ulid.ULID
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -12,11 +13,13 @@ class Packet constructor(jsonString: String = "{}") {
 
     companion object {
         internal const val READ_COUNT = "system_read_count"
+        internal const val CORRELATION_ID = "system_correlation_id"
         internal const val STARTED = "system_started"
         internal const val PROBLEM = "system_problem"
         internal const val BREADCRUMBS = "system_breadcrumbs"
 
         private val adapter = moshiInstance.adapter<Map<String, Any?>>(Map::class.java).lenient()
+        private val ulidGen =  ULID()
     }
 
     private var problem: Problem? = null
@@ -30,6 +33,9 @@ class Packet constructor(jsonString: String = "{}") {
         }
         if (!json.containsKey(STARTED)) {
             json[STARTED] = LocalDateTime.now()
+        }
+        if (!json.containsKey(CORRELATION_ID)) {
+            json[CORRELATION_ID] = ulidGen.nextULID()
         }
         json[READ_COUNT] = (json[READ_COUNT] as Double).toInt() + 1
         if (json.containsKey(PROBLEM)) {
@@ -134,23 +140,18 @@ class Packet constructor(jsonString: String = "{}") {
         }
     }
 
-    fun hasProblem(): Boolean {
-        return problem != null
-    }
+    fun getCorrelationId(): String = getStringValue(CORRELATION_ID)
+
+    fun hasProblem(): Boolean = problem != null
 
     fun addProblem(problem: Problem) {
         this.problem = problem
     }
 
-    fun getProblem(): Problem? {
-        return problem
-    }
+    fun getProblem(): Problem? = problem
 
-    fun getBreadcrumbs(): List<Breadcrumb> {
-        return breadcrumbs
-    }
+    fun getBreadcrumbs(): List<Breadcrumb> = breadcrumbs
 
-    fun getReadCount(): Int {
-        return getIntValue(READ_COUNT)
-    }
+    fun getReadCount(): Int = getIntValue(READ_COUNT)
+
 }

--- a/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
+++ b/src/main/kotlin/no/nav/dagpenger/events/Packet.kt
@@ -129,7 +129,7 @@ class Packet constructor(jsonString: String = "{}") {
         getNullableObjectValue(key, decode) ?: throw IllegalArgumentException("Null value for key=$key")
 
     fun getBoolean(key: String) = getNullableBoolean(key) ?: throw IllegalArgumentException("Null value for key=$key")
-    
+
     fun getMapValue(key: String): Map<String, Any> {
         return getValue(key).takeIf { it is Map<*, *> }.let {
             try {

--- a/src/test/kotlin/no/nav/dagpenger/events/PacketTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/events/PacketTest.kt
@@ -386,7 +386,7 @@ class PacketTest {
     }
 
     @Test
-    fun `system-correlation-id should be preserved on serialization and deserialization`(){
+    fun `system-correlation-id should be preserved on serialization and deserialization`() {
         val packet = Packet()
         Packet(packet.toJson()!!).getCorrelationId() shouldBe packet.getCorrelationId()
     }

--- a/src/test/kotlin/no/nav/dagpenger/events/PacketTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/events/PacketTest.kt
@@ -1,6 +1,7 @@
 package no.nav.dagpenger.events
 
 import com.squareup.moshi.JsonEncodingException
+import io.kotlintest.shouldBe
 import org.json.JSONObject
 
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -376,6 +377,18 @@ class PacketTest {
 
         assertFalse(packetString.contains("secretValue"))
         assertFalse(packetString.contains("problemValue"))
+    }
+
+    @Test
+    fun `Packet should have system-correlation-id`() {
+        val packet = Packet()
+        packet.hasField("system_correlation_id") shouldBe true
+    }
+
+    @Test
+    fun `system-correlation-id should be preserved on serialization and deserialization`(){
+        val packet = Packet()
+        Packet(packet.toJson()!!).getCorrelationId() shouldBe packet.getCorrelationId()
     }
 
     data class ClassA(


### PR DESCRIPTION
- Used to trace a packet and can be used as an x-correlation-id header (or nav trace id) header to external calls